### PR TITLE
Better powers

### DIFF
--- a/src/SingleSorted/AlgebraicTheory.agda
+++ b/src/SingleSorted/AlgebraicTheory.agda
@@ -1,38 +1,32 @@
 open import Agda.Primitive using (lzero; lsuc; _⊔_)
-open import Agda.Builtin.Nat using (Nat)
-open import Data.Fin using (Fin)
+open import Agda.Builtin.Nat
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Data.Fin
+
 open import Relation.Binary
 
 module SingleSorted.AlgebraicTheory where
 
-  -- Signature
+  open import SingleSorted.Context public
+
+  Arity : Set
+  Arity = Context
+
+  arg : Arity → Set
+  arg = var
+
   -- an algebraic signature
   record Signature : Set₁ where
     field
       oper : Set -- operations
-      oper-arity : oper → Nat -- the arity of an operation
+      oper-arity : oper → Arity -- the arity of an operation
 
   open Signature
-
-
-  -- Terms
-  -- A context is the same thing as a natural number (telling us how many variables are in the context)
-  Context = Nat
-
-  -- The empty context
-  empty-context = 0
-
-  -- The variables in context Γ are the elemnts of Fin Γ
-  var = Fin
-
-  -- It is absurd to have a variable in the empty context
-  empty-context-absurd : ∀ {ℓ} {A : Set ℓ} → var 0 → A
-  empty-context-absurd ()
 
   -- terms over a signature in a context of a given sort
   data Term {Σ : Signature} (Γ : Context) : Set where
     tm-var : var Γ → Term Γ
-    tm-oper : ∀ (f : oper Σ) → (Fin (oper-arity Σ f) → Term {Σ} Γ) → Term {Σ} Γ
+    tm-oper : ∀ (f : oper Σ) → (arg (oper-arity Σ f) → Term {Σ} Γ) → Term {Σ} Γ
 
   -- Substitutions (definitions - some useful properties are in another file)
   substitution : ∀ (Σ : Signature) (Γ Δ : Context) → Set
@@ -73,11 +67,14 @@ module SingleSorted.AlgebraicTheory where
       eq-symm : ∀ {Γ} {s t : Term Γ} → Γ ⊢ s ≈ t → Γ ⊢ t ≈ s
       eq-tran : ∀ {Γ} {s t u : Term Γ} → Γ ⊢ s ≈ t → Γ ⊢ t ≈ u → Γ ⊢ s ≈ u
       -- congruence rule
-      eq-congr : ∀ {Γ} {f : oper Σ} {xs ys : Fin (oper-arity Σ f) → Term Γ} →
+      eq-congr : ∀ {Γ} {f : oper Σ} {xs ys : arg (oper-arity Σ f) → Term Γ} →
                  (∀ i → Γ ⊢ xs i ≈ ys i) → Γ ⊢ tm-oper f xs ≈ tm-oper f ys
       -- equational axiom
       eq-axiom : ∀ (ε : eq) {Γ : Context} (σ : substitution Σ Γ (eq-ctx ε)) →
                  Γ ⊢ eq-lhs ε [ σ ]s ≈ eq-rhs ε [ σ ]s
+
+    ≡-⊢-≈ : {Γ : Context} {s t : Term Γ} → s ≡ t → Γ ⊢ s ≈ t
+    ≡-⊢-≈ refl = eq-refl
 
     eq-setoid : ∀ (Γ : Context) → Setoid lzero (lsuc ℓ)
     eq-setoid Γ =

--- a/src/SingleSorted/AlgebraicTheory.agda
+++ b/src/SingleSorted/AlgebraicTheory.agda
@@ -76,6 +76,14 @@ module SingleSorted.AlgebraicTheory where
     ≡-⊢-≈ : {Γ : Context} {s t : Term Γ} → s ≡ t → Γ ⊢ s ≈ t
     ≡-⊢-≈ refl = eq-refl
 
+    -- the action of the identity substitution is the identity
+    id-action : ∀ {Γ : Context} {a : Term Γ} → (Γ ⊢ a ≈ (a [ id-substitution ]s))
+    id-action {a = tm-var a} = eq-refl
+    id-action {a = tm-oper f x} = eq-congr (λ i → id-action {a = x i})
+
+    eq-axiom-id : ∀ (ε : eq) → eq-ctx ε ⊢ eq-lhs ε ≈ eq-rhs ε
+    eq-axiom-id ε = eq-tran id-action (eq-tran (eq-axiom ε id-substitution) (eq-symm id-action))
+
     eq-setoid : ∀ (Γ : Context) → Setoid lzero (lsuc ℓ)
     eq-setoid Γ =
       record

--- a/src/SingleSorted/Context.agda
+++ b/src/SingleSorted/Context.agda
@@ -1,0 +1,19 @@
+module SingleSorted.Context where
+
+-- An attempt to define more structured context
+-- that directly support the cartesian structure
+
+data Context : Set where
+  ctx-empty : Context
+  ctx-slot : Context
+  ctx-concat : Context → Context → Context
+
+-- the variables in a context
+data var : Context → Set where
+  var-var  : var ctx-slot
+  var-inl  : ∀ {Γ Δ} → var Γ → var (ctx-concat Γ Δ)
+  var-inr  : ∀ {Γ Δ} → var Δ → var (ctx-concat Γ Δ)
+
+-- It is absurd to have a variable in the empty context
+ctx-empty-absurd : ∀ {ℓ} {A : Set ℓ} → var ctx-empty → A
+ctx-empty-absurd ()

--- a/src/SingleSorted/FactsCartesian.agda
+++ b/src/SingleSorted/FactsCartesian.agda
@@ -16,46 +16,74 @@ module SingleSorted.FactsCartesian
   open Cartesian.Cartesian cartesian-𝒞 public
   open HomReasoning
 
-  -- We use our own definition of powers, because the one in the library has a silly special case n = 1
-  pow : ∀ (A : Obj) (n : Nat) → Obj
-  pow A zero = ⊤
-  pow A (suc n) = pow A n × A
+  -- Power by a context
+  pow : ∀ (A : Obj) (Γ : Context) → Obj
+  pow A ctx-empty = ⊤
+  pow A ctx-slot = A
+  pow A (ctx-concat Γ Δ) = pow A Γ × pow A Δ
 
-  pow-π : ∀ {A : Obj} {n : Nat} (i : Fin n) → pow A n ⇒ A
-  pow-π {_} {suc n} zero = π₂
-  pow-π {_} {suc n} (suc i) = (pow-π i) ∘ π₁
+  pow-π : ∀ {A : Obj} {Γ : Context} (i : var Γ) → pow A Γ ⇒ A
+  pow-π {A} var-var = id
+  pow-π {A} (var-inl i) = pow-π i ∘ π₁
+  pow-π {A} (var-inr i) = pow-π i ∘ π₂
 
   -- We make the argument n explicit because Agda has a hard time telling what it is
   -- by looking at the function.
-  pow-tuple : ∀ {A B : Obj} (n : Nat) → (Fin n → A ⇒ B) → A ⇒ pow B n
-  pow-tuple zero fs = !
-  pow-tuple (suc n) fs = ⟨ (pow-tuple n (λ i → fs (suc i))) , (fs zero) ⟩
+  pow-tuple : ∀ {A B : Obj} (Γ : Context) → (var Γ → A ⇒ B) → A ⇒ pow B Γ
+  pow-tuple ctx-empty fs =  !
+  pow-tuple ctx-slot fs = fs var-var
+  pow-tuple (ctx-concat Γ Δ) fs = ⟨ pow-tuple Γ (λ i → fs (var-inl i)) , pow-tuple Δ (λ j → fs (var-inr j)) ⟩
 
-  pow-tuple-∘ : ∀ {A B C : Obj} {n : Nat} {fs : Fin n → B ⇒ C} {g : A ⇒ B} →
-                pow-tuple n (λ i → fs i ∘ g) ≈ pow-tuple n fs ∘ g
-  pow-tuple-∘ {n = zero} {fs} {g} = !-unique (! ∘ g)
-  pow-tuple-∘ {n = suc n} {fs = fs} =
-    let open product in
-      (⟨⟩-congʳ (pow-tuple-∘ {fs = λ i → fs (suc i)})) ○ (⟺ ⟨⟩∘)
 
-  pow-tuple-id : ∀ {A : Obj} {n} → pow-tuple {A = pow A n} n pow-π ≈ id
-  pow-tuple-id {n = zero} = !-unique id
-  pow-tuple-id {n = suc n} = (⟨⟩-congʳ ((pow-tuple-∘ {n = n}) ○ ((pow-tuple-id {n = n} ⟩∘⟨refl) ○ identityˡ))) ○ η
+  pow-tuple-∘ : ∀ {A B C : Obj} {Γ : Context} {fs : var Γ → B ⇒ C} {g : A ⇒ B} →
+                pow-tuple Γ (λ i → fs i ∘ g) ≈ pow-tuple Γ fs ∘ g
+  pow-tuple-∘ {Γ = ctx-empty} {fs} {g} = !-unique (! ∘ g)
 
-  pow-tuple-eq :  ∀ {A B : Obj} {n} {f g : Fin n → A ⇒ B} → (∀ i →  f i ≈ g i) →
-                  pow-tuple n f ≈ pow-tuple n g
-  pow-tuple-eq {n = zero} _ = !-unique₂
-  pow-tuple-eq {n = suc n} ξ = ⟨⟩-cong₂ (pow-tuple-eq (λ i → ξ (suc i))) (ξ zero)
+  pow-tuple-∘ {Γ = ctx-slot} {fs} {g} = Equiv.refl
 
-  pow-tuple-id2 : ∀ {A : Obj} {n : Nat} {f : Fin n → pow A n ⇒ A} → (∀ i → f i ≈ pow-π i) → pow-tuple n f ≈ id
-  pow-tuple-id2 {A} {n} {f} ξ = pow-tuple-eq ξ ○ (pow-tuple-id {A = A} {n = n})
+  pow-tuple-∘ {Γ = ctx-concat Γ Δ} {fs} {g} =
+      begin
+      pow-tuple (ctx-concat Γ Δ) (λ i → fs i ∘ g) ≈⟨ ⟨⟩-cong₂
+                                                       (pow-tuple-∘ {fs = λ i → fs (var-inl i)})
+                                                       (pow-tuple-∘ {fs = λ i → fs (var-inr i)}) ⟩
+      ⟨ pow-tuple Γ (λ i → fs (var-inl i)) ∘ g , pow-tuple Δ (λ i → fs (var-inr i)) ∘ g ⟩
+                                                  ≈˘⟨ ⟨⟩∘ ⟩
+      pow-tuple (ctx-concat Γ Δ) fs ∘ g ∎
 
-  pow-π-tuple : ∀ {A B : Obj} {n} {fs : Fin n → A ⇒ B} {i : Fin n} →
-                (pow-π i ∘ pow-tuple n fs) ≈ fs i
-  pow-π-tuple {n = suc n} {i = zero} =  project₂
-  pow-π-tuple {A = A} {n = suc (suc n)} {fs} {i = suc i} =
+  pow-tuple-id : ∀ {A : Obj} {Γ} → pow-tuple {A = pow A Γ} Γ pow-π ≈ id
+  pow-tuple-id {Γ = ctx-empty} =  !-unique₂
+  pow-tuple-id {Γ = ctx-slot} =  Equiv.refl
+  pow-tuple-id {Γ = ctx-concat Γ Δ} =
+     ⟨⟩-cong₂
+        (pow-tuple-∘ {Γ = Γ} ○ (∘-resp-≈ˡ (pow-tuple-id {Γ = Γ}) ○ identityˡ))
+        (pow-tuple-∘ {Γ = Δ} ○ (∘-resp-≈ˡ (pow-tuple-id {Γ = Δ}) ○ identityˡ))
+     ○ η
+
+  pow-tuple-eq :  ∀ {A B : Obj} {Γ} {fs gs : var Γ → A ⇒ B} → (∀ i → fs i ≈ gs i) →
+                  pow-tuple Γ fs ≈ pow-tuple Γ gs
+  pow-tuple-eq {Γ = ctx-empty} ξ = !-unique₂
+  pow-tuple-eq {Γ = ctx-slot} ξ = ξ var-var
+  pow-tuple-eq {Γ = ctx-concat Γ Δ} ξ =
+    ⟨⟩-cong₂
+      (pow-tuple-eq (λ i → ξ (var-inl i)))
+      (pow-tuple-eq (λ j → ξ (var-inr j)))
+
+  pow-tuple-id2 : ∀ {A : Obj} {Γ} {f : var Γ → pow A Γ ⇒ A} → (∀ i → f i ≈ pow-π i) → pow-tuple Γ f ≈ id
+  pow-tuple-id2 {A} {Γ} {f} ξ = pow-tuple-eq ξ ○ (pow-tuple-id {A = A} {Γ = Γ})
+
+  pow-π-tuple : ∀ {A B : Obj} {Γ} {fs : var Γ → A ⇒ B} {i : var Γ} →
+                (pow-π i ∘ pow-tuple Γ fs) ≈ fs i
+  pow-π-tuple {i = var-var} = identityˡ
+  pow-π-tuple {Γ = ctx-concat Γ Δ} {fs = fs} {i = var-inl i} =
     begin
-      pow-π (suc i) ∘ pow-tuple (suc (suc n)) fs             ≈⟨ assoc ⟩
-      pow-π i ∘ π₁ ∘ pow-tuple (suc (suc n)) fs              ≈⟨ refl⟩∘⟨ project₁ ⟩
-      pow-π i ∘ pow-tuple (suc n) (λ j → fs (suc j))         ≈⟨ pow-π-tuple {fs = λ j → fs (suc j)} {i = i} ⟩
-      fs (suc i) ∎
+    ((pow-π i ∘ π₁) ∘ pow-tuple (ctx-concat Γ Δ) fs) ≈⟨ assoc ⟩
+    (pow-π i ∘ π₁ ∘ pow-tuple (ctx-concat Γ Δ) fs)  ≈⟨ refl⟩∘⟨ project₁ ⟩
+    (pow-π i ∘ pow-tuple Γ (λ j → fs (var-inl j))) ≈⟨ pow-π-tuple {fs = λ j → fs (var-inl j)} {i = i} ⟩
+    fs (var-inl i) ∎
+
+  pow-π-tuple {Γ = ctx-concat Γ Δ} {fs = fs} {i = var-inr i} =
+    begin
+    ((pow-π i ∘ π₂) ∘ pow-tuple (ctx-concat Γ Δ) fs) ≈⟨ assoc ⟩
+    (pow-π i ∘ π₂ ∘ pow-tuple (ctx-concat Γ Δ) fs)  ≈⟨ refl⟩∘⟨ project₂ ⟩
+    (pow-π i ∘ pow-tuple Δ (λ j → fs (var-inr j))) ≈⟨ pow-π-tuple {fs = λ j → fs (var-inr j)} {i = i} ⟩
+    fs (var-inr i) ∎

--- a/src/SingleSorted/FactsCartesian.agda
+++ b/src/SingleSorted/FactsCartesian.agda
@@ -1,5 +1,3 @@
-{-# OPTIONS --allow-unsolved-metas #-}
-
 open import Agda.Builtin.Nat
 open import Data.Fin
 

--- a/src/SingleSorted/FactsFinite.agda
+++ b/src/SingleSorted/FactsFinite.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --allow-unsolved-metas #-}
+-- This file is very likely obsolete as we do not use natural numbers and finite sets anymore
 
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; trans; cong)
 

--- a/src/SingleSorted/Interpretation.agda
+++ b/src/SingleSorted/Interpretation.agda
@@ -11,7 +11,7 @@ import SingleSorted.Power as Power
 module SingleSorted.Interpretation
          {o ℓ e}
          (Σ : Signature)
-         (𝒞 : Category.Category o ℓ e)
+         {𝒞 : Category.Category o ℓ e}
          (cartesian-𝒞 : Cartesian.Cartesian 𝒞) where
   open Signature Σ
   open Category.Category 𝒞
@@ -22,10 +22,10 @@ module SingleSorted.Interpretation
 
     field
       interp-carrier : Obj
-      interp-power :  Powered interp-carrier
-      interp-oper : ∀ (f : oper) → Powered.pow interp-power (oper-arity f) ⇒ interp-carrier
+      interp-pow :  Powered interp-carrier
+      interp-oper : ∀ (f : oper) → Powered.pow interp-pow (oper-arity f) ⇒ interp-carrier
 
-    open Powered interp-power
+    open Powered interp-pow
 
     -- the interpretation of a term
     interp-term : ∀ {Γ : Context} → Term {Σ} Γ → (pow Γ) ⇒ interp-carrier
@@ -43,17 +43,17 @@ module SingleSorted.Interpretation
     -- interpretation commutes with substitution
     open HomReasoning
 
-    interp-[]s : ∀ {Γ Δ} (t : Term Δ) (σ : substitution Σ Γ Δ) →
+    interp-[]s : ∀ {Γ Δ} {t : Term Δ} {σ : substitution Σ Γ Δ} →
                  interp-term (t [ σ ]s) ≈ interp-term t ∘ interp-subst σ
-    interp-[]s {Γ} {Δ} (tm-var x) σ = ⟺ (project {Γ = Δ})
-    interp-[]s {Γ} {Δ} (tm-oper f ts) σ = (∘-resp-≈ʳ
+    interp-[]s {Γ} {Δ} {tm-var x} {σ} = ⟺ (project {Γ = Δ})
+    interp-[]s {Γ} {Δ} {tm-oper f ts} {σ} = (∘-resp-≈ʳ
                                             (tuple-cong
                                               {fs = λ i → interp-term (ts i [ σ ]s)}
                                               {gs = λ z → interp-term (ts z) ∘ interp-subst σ}
-                                              (λ i → interp-[]s (ts i) σ)
+                                              (λ i → interp-[]s {t = ts i} {σ = σ})
                                           ○ (∘-distribʳ-tuple
                                               {Γ = oper-arity f}
-                                              {ts = λ z → interp-term (ts z)}
+                                              {fs = λ z → interp-term (ts z)}
                                               {g = interp-subst σ})))
                                             ○ (Equiv.refl ○ sym-assoc)
 
@@ -64,35 +64,36 @@ module SingleSorted.Interpretation
     let open Cartesian.Cartesian cartesian-𝒞 in
     record
       { interp-carrier = ⊤
-      ; interp-power = record { pow = λ Γ → ⊤ ; π = {!!} ; tuple = {!!} ; project = {!!} ; unique = {!!} }
-      ; interp-oper = {!!} }
+      ; interp-pow = StandardPowered cartesian-𝒞 ⊤
+      ; interp-oper = λ f → ! }
 
-  -- record HomI (A B : Interpretation) : Set (o ⊔ ℓ ⊔ e) where
-  --   open Interpretation
+  record HomI (A B : Interpretation) : Set (o ⊔ ℓ ⊔ e) where
+    open Interpretation
+    open Powered
 
-  --   field
-  --     hom-morphism : interp-carrier A  ⇒ interp-carrier B
-  --     hom-commute :
-  --        ∀ (f : oper) →
-  --        hom-morphism ∘ interp-oper A f ≈
-  --            interp-oper B f ∘ pow-tuple (oper-arity f) (λ i → hom-morphism ∘ pow-π i)
+    field
+      hom-morphism : interp-carrier A  ⇒ interp-carrier B
+      hom-commute :
+         ∀ (f : oper) →
+         hom-morphism ∘ interp-oper A f ≈
+             interp-oper B f ∘ tuple (interp-pow B) (oper-arity f) (λ i → hom-morphism ∘ π (interp-pow A) i)
 
-  -- -- The identity homomorphism
-  -- IdI : ∀ (A : Interpretation) → HomI A A
-  -- IdI A =
-  --   let open Interpretation A in
-  --   let open HomReasoning in
-  --   record
-  --     { hom-morphism = id
-  --     ; hom-commute =
-  --        λ f →
-  --         begin
-  --           (id ∘ interp-oper f)       ≈⟨ identityˡ ⟩
-  --           interp-oper f             ≈˘⟨ identityʳ ⟩
-  --           (interp-oper f ∘ id)      ≈˘⟨ (refl⟩∘⟨ pow-tuple-id2 {Γ = oper-arity f} λ i → identityˡ) ⟩
-  --           (interp-oper f ∘ pow-tuple (oper-arity f) (λ i → id ∘ pow-π i)) ∎
-
-  --     }
+  -- The identity homomorphism
+  IdI : ∀ (A : Interpretation) → HomI A A
+  IdI A =
+    let open Interpretation A in
+    let open HomReasoning in
+    let open Powered interp-pow in
+    record
+      { hom-morphism = id
+      ; hom-commute =
+         λ f →
+          begin
+            (id ∘ interp-oper f)       ≈⟨ identityˡ ⟩
+            interp-oper f             ≈˘⟨ identityʳ ⟩
+            (interp-oper f ∘ id)      ≈˘⟨ refl⟩∘⟨ unique (λ i → identityʳ ○ ⟺ identityˡ) ⟩
+            (interp-oper f ∘ tuple (oper-arity f) (λ i → id ∘ π i)) ∎
+      }
 
   -- -- Compositon of homomorphisms
   -- _∘I_ : ∀ {A B C : Interpretation} → HomI B C → HomI A B → HomI A C

--- a/src/SingleSorted/Interpretation.agda
+++ b/src/SingleSorted/Interpretation.agda
@@ -1,5 +1,3 @@
-{-# OPTIONS --allow-unsolved-metas #-}
-
 open import Agda.Primitive using (_⊔_)
 
 import Categories.Category as Category

--- a/src/SingleSorted/Interpretation.agda
+++ b/src/SingleSorted/Interpretation.agda
@@ -1,117 +1,125 @@
 {-# OPTIONS --allow-unsolved-metas #-}
 
 open import Agda.Primitive using (_⊔_)
-open import Agda.Builtin.Nat
 
 import Categories.Category as Category
 import Categories.Category.Cartesian as Cartesian
 
 open import SingleSorted.AlgebraicTheory
-import SingleSorted.FactsCartesian
+import SingleSorted.Power as Power
 
 module SingleSorted.Interpretation
          {o ℓ e}
-         (Σ : Signature) {𝒞 : Category.Category o ℓ e}
+         (Σ : Signature)
+         (𝒞 : Category.Category o ℓ e)
          (cartesian-𝒞 : Cartesian.Cartesian 𝒞) where
   open Signature Σ
   open Category.Category 𝒞
-  open SingleSorted.FactsCartesian cartesian-𝒞
+  open Power 𝒞
 
   -- An interpretation of Σ in 𝒞
   record Interpretation : Set (o ⊔ ℓ ⊔ e) where
 
     field
       interp-carrier : Obj
-      interp-oper : ∀ (f : oper) → pow interp-carrier (oper-arity f) ⇒ interp-carrier
+      interp-power :  Powered interp-carrier
+      interp-oper : ∀ (f : oper) → Powered.pow interp-power (oper-arity f) ⇒ interp-carrier
+
+    open Powered interp-power
 
     -- the interpretation of a term
-    interp-term : ∀ {Γ : Context} → Term {Σ} Γ →  (pow interp-carrier Γ) ⇒ interp-carrier
-    interp-term (tm-var x) = pow-π x
-    interp-term (tm-oper f ts) = interp-oper f ∘ pow-tuple (oper-arity f) (λ i → interp-term (ts i))
+    interp-term : ∀ {Γ : Context} → Term {Σ} Γ → (pow Γ) ⇒ interp-carrier
+    interp-term (tm-var x) = π x
+    interp-term (tm-oper f ts) = interp-oper f ∘ tuple (oper-arity f) (λ i → interp-term (ts i))
 
     -- the interpretation of a context
     interp-ctx : Context → Obj
-    interp-ctx Γ = pow interp-carrier Γ
+    interp-ctx Γ = pow Γ
 
     -- the interpretation of a substitution
     interp-subst : ∀ {Γ Δ} → substitution Σ Γ Δ → interp-ctx Γ ⇒ interp-ctx Δ
-    interp-subst {Γ} {Δ} σ = pow-tuple Δ λ i → interp-term (σ i)
+    interp-subst {Γ} {Δ} σ = tuple Δ λ i → interp-term (σ i)
 
     -- interpretation commutes with substitution
     open HomReasoning
 
     interp-[]s : ∀ {Γ Δ} (t : Term Δ) (σ : substitution Σ Γ Δ) →
                  interp-term (t [ σ ]s) ≈ interp-term t ∘ interp-subst σ
-    interp-[]s {Γ} {Δ} (tm-var x) σ = ⟺ (pow-π-tuple {n = Δ})
+    interp-[]s {Γ} {Δ} (tm-var x) σ = ⟺ (project {Γ = Δ})
     interp-[]s {Γ} {Δ} (tm-oper f ts) σ = (∘-resp-≈ʳ
-                                            (pow-tuple-eq
-                                              {f = λ i → interp-term (ts i [ σ ]s)}
-                                              {g = λ z → interp-term (ts z) ∘ interp-subst σ}
+                                            (tuple-cong
+                                              {fs = λ i → interp-term (ts i [ σ ]s)}
+                                              {gs = λ z → interp-term (ts z) ∘ interp-subst σ}
                                               (λ i → interp-[]s (ts i) σ)
-                                          ○ (pow-tuple-∘
-                                              {n = oper-arity f}
-                                              {fs = λ z → interp-term (ts z)}
+                                          ○ (∘-distribʳ-tuple
+                                              {Γ = oper-arity f}
+                                              {ts = λ z → interp-term (ts z)}
                                               {g = interp-subst σ})))
                                             ○ (Equiv.refl ○ sym-assoc)
 
-  -- Every signature has the trivial interpretation
+  -- -- Every signature has the trivial interpretation
 
-  TrivialI : Interpretation
-  TrivialI = record { interp-carrier = ⊤ ; interp-oper = λ f → ! }
-
-  record HomI (A B : Interpretation) : Set (o ⊔ ℓ ⊔ e) where
-    open Interpretation
-
-    field
-      hom-morphism : interp-carrier A  ⇒ interp-carrier B
-      hom-commute :
-         ∀ (f : oper) →
-         hom-morphism ∘ interp-oper A f ≈
-             interp-oper B f ∘ pow-tuple (oper-arity f) (λ i → hom-morphism ∘ pow-π i)
-
-  -- The identity homomorphism
-  IdI : ∀ (A : Interpretation) → HomI A A
-  IdI A =
-    let open Interpretation A in
-    let open HomReasoning in
+  Trivial : Interpretation
+  Trivial =
+    let open Cartesian.Cartesian cartesian-𝒞 in
     record
-      { hom-morphism = id
-      ; hom-commute =
-         λ f →
-          begin
-            (id ∘ interp-oper f)       ≈⟨ identityˡ ⟩
-            interp-oper f             ≈˘⟨ identityʳ ⟩
-            (interp-oper f ∘ id)      ≈˘⟨ (refl⟩∘⟨ pow-tuple-id2 {n = oper-arity f} λ i → identityˡ) ⟩
-            (interp-oper f ∘ pow-tuple (oper-arity f) (λ i → id ∘ pow-π i)) ∎
+      { interp-carrier = ⊤
+      ; interp-power = record { pow = λ Γ → ⊤ ; π = {!!} ; tuple = {!!} ; project = {!!} ; unique = {!!} }
+      ; interp-oper = {!!} }
 
-      }
+  -- record HomI (A B : Interpretation) : Set (o ⊔ ℓ ⊔ e) where
+  --   open Interpretation
 
-  -- Compositon of homomorphisms
-  _∘I_ : ∀ {A B C : Interpretation} → HomI B C → HomI A B → HomI A C
-  _∘I_ {A} {B} {C} ϕ ψ =
-    let open HomI in
-    record
-      { hom-morphism = (hom-morphism ϕ) ∘ (hom-morphism ψ)
-      ; hom-commute =
-          let open Interpretation in
-          let open HomReasoning in
-          λ f → let n = oper-arity f in
-            begin
-              ((hom-morphism ϕ ∘ hom-morphism ψ) ∘ interp-oper A f)
-            ≈⟨ assoc ⟩
-              (hom-morphism ϕ ∘ hom-morphism ψ ∘ interp-oper A f)
-            ≈⟨ refl⟩∘⟨ hom-commute ψ f ⟩
-              (hom-morphism ϕ ∘ interp-oper B f ∘ pow-tuple n (λ i → hom-morphism ψ ∘ pow-π i))
-            ≈˘⟨  assoc ⟩
-              ((hom-morphism ϕ ∘ interp-oper B f) ∘ pow-tuple n (λ i → hom-morphism ψ ∘ pow-π i))
-            ≈⟨  hom-commute ϕ f ⟩∘⟨refl ⟩
-              (interp-oper C f ∘
-               pow-tuple n (λ i → hom-morphism ϕ ∘ pow-π i)) ∘
-               pow-tuple n (λ i → hom-morphism ψ ∘ pow-π i)
-            ≈⟨ assoc ⟩
-              (interp-oper C f ∘
-               pow-tuple n (λ i → hom-morphism ϕ ∘ pow-π i) ∘
-               pow-tuple n (λ i → hom-morphism ψ ∘ pow-π i))
-            ≈⟨ (refl⟩∘⟨ Equiv.sym (pow-tuple-∘ {n = oper-arity f} {fs = λ i → hom-morphism ϕ ∘ pow-π i} {g = pow-tuple (oper-arity f) (λ i → hom-morphism ψ ∘ pow-π i)})) ⟩
-              {!!}
-      }
+  --   field
+  --     hom-morphism : interp-carrier A  ⇒ interp-carrier B
+  --     hom-commute :
+  --        ∀ (f : oper) →
+  --        hom-morphism ∘ interp-oper A f ≈
+  --            interp-oper B f ∘ pow-tuple (oper-arity f) (λ i → hom-morphism ∘ pow-π i)
+
+  -- -- The identity homomorphism
+  -- IdI : ∀ (A : Interpretation) → HomI A A
+  -- IdI A =
+  --   let open Interpretation A in
+  --   let open HomReasoning in
+  --   record
+  --     { hom-morphism = id
+  --     ; hom-commute =
+  --        λ f →
+  --         begin
+  --           (id ∘ interp-oper f)       ≈⟨ identityˡ ⟩
+  --           interp-oper f             ≈˘⟨ identityʳ ⟩
+  --           (interp-oper f ∘ id)      ≈˘⟨ (refl⟩∘⟨ pow-tuple-id2 {Γ = oper-arity f} λ i → identityˡ) ⟩
+  --           (interp-oper f ∘ pow-tuple (oper-arity f) (λ i → id ∘ pow-π i)) ∎
+
+  --     }
+
+  -- -- Compositon of homomorphisms
+  -- _∘I_ : ∀ {A B C : Interpretation} → HomI B C → HomI A B → HomI A C
+  -- _∘I_ {A} {B} {C} ϕ ψ =
+  --   let open HomI in
+  --   record
+  --     { hom-morphism = (hom-morphism ϕ) ∘ (hom-morphism ψ)
+  --     ; hom-commute =
+  --         let open Interpretation in
+  --         let open HomReasoning in
+  --         λ f → let n = oper-arity f in
+  --           begin
+  --             ((hom-morphism ϕ ∘ hom-morphism ψ) ∘ interp-oper A f)
+  --           ≈⟨ assoc ⟩
+  --             (hom-morphism ϕ ∘ hom-morphism ψ ∘ interp-oper A f)
+  --           ≈⟨ refl⟩∘⟨ hom-commute ψ f ⟩
+  --             (hom-morphism ϕ ∘ interp-oper B f ∘ pow-tuple n (λ i → hom-morphism ψ ∘ pow-π i))
+  --           ≈˘⟨  assoc ⟩
+  --             ((hom-morphism ϕ ∘ interp-oper B f) ∘ pow-tuple n (λ i → hom-morphism ψ ∘ pow-π i))
+  --           ≈⟨  hom-commute ϕ f ⟩∘⟨refl ⟩
+  --             (interp-oper C f ∘
+  --              pow-tuple n (λ i → hom-morphism ϕ ∘ pow-π i)) ∘
+  --              pow-tuple n (λ i → hom-morphism ψ ∘ pow-π i)
+  --           ≈⟨ assoc ⟩
+  --             (interp-oper C f ∘
+  --              pow-tuple n (λ i → hom-morphism ϕ ∘ pow-π i) ∘
+  --              pow-tuple n (λ i → hom-morphism ψ ∘ pow-π i))
+  --           ≈⟨ (refl⟩∘⟨ Equiv.sym (pow-tuple-∘ {Γ = oper-arity f} {fs = λ i → hom-morphism ϕ ∘ pow-π i} {g = pow-tuple (oper-arity f) (λ i → hom-morphism ψ ∘ pow-π i)})) ⟩
+  --             {!!}
+  --     }

--- a/src/SingleSorted/Model.agda
+++ b/src/SingleSorted/Model.agda
@@ -3,25 +3,22 @@
 open import Agda.Primitive using (_⊔_)
 
 import Categories.Category as Category
-import Categories.Category.Cartesian as Cartesian
-
 import SingleSorted.Interpretation as Interpretation
-import SingleSorted.FactsCartesian as FactsCartesian
 
 open import SingleSorted.AlgebraicTheory
 open import SingleSorted.Substitution
+import SingleSorted.Power as Power
 
 module SingleSorted.Model {o ℓ e ℓt}
           {Σ : Signature}
           (T : Theory ℓt Σ)
-          {𝒞 : Category.Category o ℓ e}
-          {cartesian-𝒞 : Cartesian.Cartesian 𝒞} where
+          {𝒞 : Category.Category o ℓ e} where
 
   open Signature Σ
 
   -- Model of a theory
 
-  record Model (I : Interpretation.Interpretation Σ cartesian-𝒞)  : Set (ℓt ⊔ o ⊔ ℓ ⊔ e) where
+  record Model (I : Interpretation.Interpretation Σ 𝒞)  : Set (ℓt ⊔ o ⊔ ℓ ⊔ e) where
 
     open Interpretation.Interpretation I
     open Category.Category 𝒞
@@ -31,20 +28,19 @@ module SingleSorted.Model {o ℓ e ℓt}
     field
       model-eq : ∀ (ε : eq) → interp-term (eq-lhs ε) ≈ interp-term (eq-rhs ε)
 
-
     -- Soundness of semantics
     module _ where
-      open FactsCartesian cartesian-𝒞
+      open Power.Powered interp-power
 
       model-⊢-≈ : ∀ {Γ} {s t : Term Γ} → Γ ⊢ s ≈ t → interp-term s ≈ interp-term t
       model-⊢-≈ eq-refl =  Equiv.refl
       model-⊢-≈ (eq-symm ξ) = ⟺ (model-⊢-≈ ξ)
       model-⊢-≈ (eq-tran ξ θ) = (model-⊢-≈ ξ) ○ (model-⊢-≈ θ)
-      model-⊢-≈ (eq-congr ξ) = refl⟩∘⟨ pow-tuple-eq (λ i → model-⊢-≈ (ξ i))
-      model-⊢-≈ (eq-axiom ε σ) = interp-[]s (eq-lhs ε) σ ○ (∘-resp-≈ˡ (model-eq ε) ○ (⟺ (interp-[]s (eq-rhs ε) σ)))
+      model-⊢-≈ (eq-congr ξ) = ∘-resp-≈ʳ (unique (λ i → project ○ model-⊢-≈ (eq-symm (ξ i))))
+      model-⊢-≈ (eq-axiom ε σ) = {!!}
 
   -- Every theory has the trivial model, whose carrier is the terminal object
   TrivialM : Model (Interpretation.TrivialI Σ cartesian-𝒞)
   TrivialM =
-     let open Cartesian.Cartesian cartesian-𝒞 in
-     record { model-eq = λ ε → !-unique₂ }
+     let open Power.Powered interp-power in
+     record { model-eq = λ ε → ! }

--- a/src/SingleSorted/Model.agda
+++ b/src/SingleSorted/Model.agda
@@ -3,6 +3,7 @@
 open import Agda.Primitive using (_⊔_)
 
 import Categories.Category as Category
+import Categories.Category.Cartesian as Cartesian
 import SingleSorted.Interpretation as Interpretation
 
 open import SingleSorted.AlgebraicTheory
@@ -12,13 +13,14 @@ import SingleSorted.Power as Power
 module SingleSorted.Model {o ℓ e ℓt}
           {Σ : Signature}
           (T : Theory ℓt Σ)
-          {𝒞 : Category.Category o ℓ e} where
+          {𝒞 : Category.Category o ℓ e}
+          (cartesian-𝒞 : Cartesian.Cartesian 𝒞) where
 
   open Signature Σ
 
   -- Model of a theory
 
-  record Model (I : Interpretation.Interpretation Σ 𝒞)  : Set (ℓt ⊔ o ⊔ ℓ ⊔ e) where
+  record Model (I : Interpretation.Interpretation Σ cartesian-𝒞) : Set (ℓt ⊔ o ⊔ ℓ ⊔ e) where
 
     open Interpretation.Interpretation I
     open Category.Category 𝒞
@@ -37,10 +39,11 @@ module SingleSorted.Model {o ℓ e ℓt}
       model-⊢-≈ (eq-symm ξ) = ⟺ (model-⊢-≈ ξ)
       model-⊢-≈ (eq-tran ξ θ) = (model-⊢-≈ ξ) ○ (model-⊢-≈ θ)
       model-⊢-≈ (eq-congr ξ) = ∘-resp-≈ʳ (unique (λ i → project ○ model-⊢-≈ (eq-symm (ξ i))))
-      model-⊢-≈ (eq-axiom ε σ) = {!!}
+      model-⊢-≈ (eq-axiom ε σ) =
+        interp-[]s {t = eq-lhs ε} {σ = σ} ○ (∘-resp-≈ˡ (model-⊢-≈ {!!}) ○ ⟺ (interp-[]s {t = eq-rhs ε} {σ = σ}))
 
   -- Every theory has the trivial model, whose carrier is the terminal object
-  TrivialM : Model (Interpretation.TrivialI Σ cartesian-𝒞)
-  TrivialM =
-     let open Power.Powered interp-power in
-     record { model-eq = λ ε → ! }
+  Trivial : Model (Interpretation.Trivial Σ cartesian-𝒞)
+  Trivial =
+    let open Cartesian.Cartesian cartesian-𝒞 in
+    record { model-eq = λ ε → !-unique₂ }

--- a/src/SingleSorted/Model.agda
+++ b/src/SingleSorted/Model.agda
@@ -20,10 +20,10 @@ module SingleSorted.Model {o ℓ e ℓt}
 
   record Model (I : Interpretation.Interpretation Σ cartesian-𝒞) : Set (ℓt ⊔ o ⊔ ℓ ⊔ e) where
 
-    open Interpretation.Interpretation I
-    open Category.Category 𝒞
-    open HomReasoning
     open Theory T
+    open Category.Category 𝒞
+    open Interpretation.Interpretation I
+    open HomReasoning
 
     field
       model-eq : ∀ (ε : eq) → interp-term (eq-lhs ε) ≈ interp-term (eq-rhs ε)
@@ -32,13 +32,23 @@ module SingleSorted.Model {o ℓ e ℓt}
     module _ where
       open Power.Powered interp-pow
 
-      -- model-⊢-≈ : ∀ {Γ} {s t : Term Γ} → Γ ⊢ s ≈ t → interp-term s ≈ interp-term t
-      -- model-⊢-≈ eq-refl =  Equiv.refl
-      -- model-⊢-≈ (eq-symm ξ) = ⟺ (model-⊢-≈ ξ)
-      -- model-⊢-≈ (eq-tran ξ θ) = (model-⊢-≈ ξ) ○ (model-⊢-≈ θ)
-      -- model-⊢-≈ (eq-congr ξ) = ∘-resp-≈ʳ (unique (λ i → project ○ model-⊢-≈ (eq-symm (ξ i))))
-      -- model-⊢-≈ (eq-axiom ε σ) =
-      --   interp-[]s {t = eq-lhs ε} {σ = σ} ○ (∘-resp-≈ˡ (model-⊢-≈ (eq-axiom-id ε)) ○ ⟺ (interp-[]s {t = eq-rhs ε} {σ = σ}))
+      -- first we show that substitution preserves validity
+      model-resp-[]s : ∀ {Γ Δ} {u v : Term Γ} {σ : substitution Σ Δ Γ} →
+                       interp-term u ≈ interp-term v → interp-term (u [ σ ]s) ≈ interp-term (v [ σ ]s)
+      model-resp-[]s {u = u} {v = v} {σ = σ} ξ =
+        begin
+          interp-term (u [ σ ]s) ≈⟨  interp-[]s {t = u} ⟩
+          (interp-term u ∘ interp-subst σ)  ≈⟨ ξ ⟩∘⟨refl ⟩
+          (interp-term v ∘ interp-subst σ) ≈˘⟨ interp-[]s {t = v} ⟩
+          interp-term (v [ σ ]s) ∎
+
+      -- the soundness statement
+      model-⊢-≈ : ∀ {Γ} {s t : Term Γ} → Γ ⊢ s ≈ t → interp-term s ≈ interp-term t
+      model-⊢-≈ eq-refl =  Equiv.refl
+      model-⊢-≈ (eq-symm ξ) = ⟺ (model-⊢-≈ ξ)
+      model-⊢-≈ (eq-tran ξ θ) = (model-⊢-≈ ξ) ○ (model-⊢-≈ θ)
+      model-⊢-≈ (eq-congr ξ) = ∘-resp-≈ʳ (unique (λ i → project ○ model-⊢-≈ (eq-symm (ξ i))))
+      model-⊢-≈ (eq-axiom ε σ) = model-resp-[]s {u = eq-lhs ε} {v = eq-rhs ε} (model-eq ε)
 
   -- Every theory has the trivial model, whose carrier is the terminal object
   Trivial : Model (Interpretation.Trivial Σ cartesian-𝒞)

--- a/src/SingleSorted/Model.agda
+++ b/src/SingleSorted/Model.agda
@@ -1,5 +1,3 @@
-{-# OPTIONS --allow-unsolved-metas #-}
-
 open import Agda.Primitive using (_⊔_)
 
 import Categories.Category as Category
@@ -32,15 +30,15 @@ module SingleSorted.Model {o ℓ e ℓt}
 
     -- Soundness of semantics
     module _ where
-      open Power.Powered interp-power
+      open Power.Powered interp-pow
 
-      model-⊢-≈ : ∀ {Γ} {s t : Term Γ} → Γ ⊢ s ≈ t → interp-term s ≈ interp-term t
-      model-⊢-≈ eq-refl =  Equiv.refl
-      model-⊢-≈ (eq-symm ξ) = ⟺ (model-⊢-≈ ξ)
-      model-⊢-≈ (eq-tran ξ θ) = (model-⊢-≈ ξ) ○ (model-⊢-≈ θ)
-      model-⊢-≈ (eq-congr ξ) = ∘-resp-≈ʳ (unique (λ i → project ○ model-⊢-≈ (eq-symm (ξ i))))
-      model-⊢-≈ (eq-axiom ε σ) =
-        interp-[]s {t = eq-lhs ε} {σ = σ} ○ (∘-resp-≈ˡ (model-⊢-≈ {!!}) ○ ⟺ (interp-[]s {t = eq-rhs ε} {σ = σ}))
+      -- model-⊢-≈ : ∀ {Γ} {s t : Term Γ} → Γ ⊢ s ≈ t → interp-term s ≈ interp-term t
+      -- model-⊢-≈ eq-refl =  Equiv.refl
+      -- model-⊢-≈ (eq-symm ξ) = ⟺ (model-⊢-≈ ξ)
+      -- model-⊢-≈ (eq-tran ξ θ) = (model-⊢-≈ ξ) ○ (model-⊢-≈ θ)
+      -- model-⊢-≈ (eq-congr ξ) = ∘-resp-≈ʳ (unique (λ i → project ○ model-⊢-≈ (eq-symm (ξ i))))
+      -- model-⊢-≈ (eq-axiom ε σ) =
+      --   interp-[]s {t = eq-lhs ε} {σ = σ} ○ (∘-resp-≈ˡ (model-⊢-≈ (eq-axiom-id ε)) ○ ⟺ (interp-[]s {t = eq-rhs ε} {σ = σ}))
 
   -- Every theory has the trivial model, whose carrier is the terminal object
   Trivial : Model (Interpretation.Trivial Σ cartesian-𝒞)

--- a/src/SingleSorted/Power.agda
+++ b/src/SingleSorted/Power.agda
@@ -37,8 +37,8 @@ module SingleSorted.Power
                  tuple Γ fs ≈ tuple Γ gs
     tuple-cong ξ = unique (λ i →  project ○ ⟺ (ξ i))
 
-    ∘-distribʳ-tuple : ∀ {B C} {Γ} {ts : var Γ → B ⇒ A} {g : C ⇒ B}  →
-                       tuple Γ (λ x → ts x ∘ g) ≈ tuple Γ ts ∘ g
+    ∘-distribʳ-tuple : ∀ {B C} {Γ} {fs : var Γ → B ⇒ A} {g : C ⇒ B}  →
+                       tuple Γ (λ x → fs x ∘ g) ≈ tuple Γ fs ∘ g
     ∘-distribʳ-tuple = unique (λ i → ⟺ assoc ○ ∘-resp-≈ˡ project)
 
   -- A cartesian category has a standard power structure (which we need not use)
@@ -56,9 +56,9 @@ module SingleSorted.Power
     standard-π (var-inr i) = standard-π i ∘ π₂
 
     standard-tuple : ∀ Γ {B} → (var Γ → B ⇒ A) → B ⇒ standard-pow Γ
-    standard-tuple ctx-empty ts = !
-    standard-tuple ctx-slot ts = ts var-var
-    standard-tuple (ctx-concat Γ Δ) ts = ⟨ standard-tuple Γ (λ i → ts (var-inl i)) , standard-tuple Δ (λ j → ts (var-inr j)) ⟩
+    standard-tuple ctx-empty fs = !
+    standard-tuple ctx-slot fs = fs var-var
+    standard-tuple (ctx-concat Γ Δ) fs = ⟨ standard-tuple Γ (λ i → fs (var-inl i)) , standard-tuple Δ (λ j → fs (var-inr j)) ⟩
 
     standard-project : ∀ {Γ} {B} {x : var Γ} {fs : var Γ → B ⇒ A} →
                        standard-π x ∘ standard-tuple Γ fs ≈ fs x
@@ -70,13 +70,16 @@ module SingleSorted.Power
                       standard-tuple Γ fs ≈ g
     standard-unique {ctx-empty} ξ = !-unique _
     standard-unique {ctx-slot} ξ = ⟺ (ξ var-var) ○ identityˡ
-    standard-unique {ctx-concat Γ Δ} ξ = {!!}
+    standard-unique {ctx-concat Γ Δ} {fs = fs} ξ =
+      unique
+         (⟺ (standard-unique (λ x → sym-assoc ○ (ξ (var-inl x)))))
+         (⟺ (standard-unique (λ y → sym-assoc ○ (ξ (var-inr y)))))
 
-    Standard : Powered A
-    Standard =
+    StandardPowered : Powered A
+    StandardPowered =
       record
       { pow = standard-pow
       ; π = standard-π
       ; tuple = standard-tuple
-      ; project = standard-project
+      ; project = λ {Γ} → standard-project {Γ}
       ; unique = standard-unique }

--- a/src/SingleSorted/Power.agda
+++ b/src/SingleSorted/Power.agda
@@ -1,0 +1,82 @@
+open import Agda.Primitive using (_⊔_)
+
+import Categories.Category as Category
+import Categories.Category.Cartesian as Cartesian
+
+open import SingleSorted.Context
+
+module SingleSorted.Power
+       {o ℓ e}
+       (𝒞 : Category.Category o ℓ e) where
+
+  open Category.Category 𝒞
+  open HomReasoning
+
+  record Powered (A : Obj) : Set (o ⊔ ℓ ⊔ e) where
+
+    field
+      pow : Context → Obj
+      π : ∀ {Γ} → var Γ → pow Γ ⇒ A
+      tuple : ∀ Γ {B} → (var Γ → B ⇒ A) → B ⇒ pow Γ
+      project : ∀ {Γ} {B} {x : var Γ} {fs : var Γ → B ⇒ A} → π x ∘ tuple Γ fs ≈ fs x
+      unique : ∀ {Γ} {B} {fs : var Γ → B ⇒ A} {g : B ⇒ pow Γ} → (∀ i → π i ∘ g ≈ fs i) → tuple Γ fs ≈ g
+
+    η : ∀ {Γ} → tuple Γ π ≈ id
+    η = unique (λ i → identityʳ)
+
+    ! : ∀ {B : Obj} → B ⇒ pow ctx-empty
+    ! = tuple ctx-empty ctx-empty-absurd
+
+    !-unique : ∀ {B : Obj} {f : B ⇒ pow ctx-empty} → ! ≈ f
+    !-unique = unique λ i → ctx-empty-absurd i
+
+    !-unique₂ : ∀ {B : Obj} {f g : B ⇒ pow ctx-empty} → f ≈ g
+    !-unique₂ = (⟺ !-unique) ○ !-unique
+
+    tuple-cong : ∀ {B : Obj} {Γ} {fs gs : var Γ → B ⇒ A} → (∀ i → fs i ≈ gs i) →
+                 tuple Γ fs ≈ tuple Γ gs
+    tuple-cong ξ = unique (λ i →  project ○ ⟺ (ξ i))
+
+    ∘-distribʳ-tuple : ∀ {B C} {Γ} {ts : var Γ → B ⇒ A} {g : C ⇒ B}  →
+                       tuple Γ (λ x → ts x ∘ g) ≈ tuple Γ ts ∘ g
+    ∘-distribʳ-tuple = unique (λ i → ⟺ assoc ○ ∘-resp-≈ˡ project)
+
+  -- A cartesian category has a standard power structure (which we need not use)
+  module _ (cartesian-𝒞 : Cartesian.Cartesian 𝒞) (A : Obj) where
+    open Cartesian.Cartesian cartesian-𝒞
+
+    standard-pow : Context → Obj
+    standard-pow ctx-empty = ⊤
+    standard-pow ctx-slot = A
+    standard-pow (ctx-concat Γ Δ) = standard-pow Γ × standard-pow Δ
+
+    standard-π : ∀ {Γ} → var Γ → standard-pow Γ ⇒ A
+    standard-π var-var = id
+    standard-π (var-inl i) = standard-π i ∘ π₁
+    standard-π (var-inr i) = standard-π i ∘ π₂
+
+    standard-tuple : ∀ Γ {B} → (var Γ → B ⇒ A) → B ⇒ standard-pow Γ
+    standard-tuple ctx-empty ts = !
+    standard-tuple ctx-slot ts = ts var-var
+    standard-tuple (ctx-concat Γ Δ) ts = ⟨ standard-tuple Γ (λ i → ts (var-inl i)) , standard-tuple Δ (λ j → ts (var-inr j)) ⟩
+
+    standard-project : ∀ {Γ} {B} {x : var Γ} {fs : var Γ → B ⇒ A} →
+                       standard-π x ∘ standard-tuple Γ fs ≈ fs x
+    standard-project {x = var-var} = identityˡ
+    standard-project {x = var-inl x} = assoc ○ ((∘-resp-≈ʳ project₁) ○ standard-project {x = x})
+    standard-project {x = var-inr x} = assoc ○ ((∘-resp-≈ʳ project₂) ○ standard-project {x = x})
+
+    standard-unique : ∀ {Γ} {B} {fs : var Γ → B ⇒ A} {g : B ⇒ standard-pow Γ} → (∀ i → standard-π i ∘ g ≈ fs i) →
+                      standard-tuple Γ fs ≈ g
+    standard-unique {ctx-empty} ξ = !-unique _
+    standard-unique {ctx-slot} ξ = ⟺ (ξ var-var) ○ identityˡ
+    standard-unique {ctx-concat Γ Δ} ξ = {!!}
+
+    Standard : Powered A
+    Standard =
+      record
+      { pow = standard-pow
+      ; π = standard-π
+      ; tuple = standard-tuple
+      ; project = standard-project
+      ; unique = standard-unique }

--- a/src/SingleSorted/Substitution.agda
+++ b/src/SingleSorted/Substitution.agda
@@ -7,11 +7,6 @@ module SingleSorted.Substitution {ℓ} {Σ : Signature} (T : Theory ℓ Σ) wher
 
   open Theory T
 
-  -- the action of the identity substitution is the identity
-  id-action : ∀ {Γ : Context} {a : Term Γ} → (Γ ⊢ a ≈ (a [ id-substitution ]s))
-  id-action {a = tm-var a} = eq-refl
-  id-action {a = tm-oper f x} = eq-congr (λ i → id-action {a = x i})
-
   -- an equality is preserved by the action of the identity
   eq-id-action : ∀ {Γ : Context} {u v : Term Γ} → (Γ ⊢ (u [ id-substitution ]s) ≈ (v [ id-substitution ]s)) → (Γ ⊢ u ≈ v)
   eq-id-action {u = u} {v = v} p = eq-tran (id-action {a = u}) (eq-tran p (eq-symm (id-action {a = v})))

--- a/src/SingleSorted/Substitution.agda
+++ b/src/SingleSorted/Substitution.agda
@@ -20,6 +20,8 @@ module SingleSorted.Substitution {ℓ} {Σ : Signature} (T : Theory ℓ Σ) wher
   _≈s_ : ∀ {Γ Δ : Context} → substitution Σ Γ Δ → substitution Σ Γ Δ → Set (lsuc ℓ)
   _≈s_ {Γ = Γ} σ ρ = ∀ x → Γ ⊢ σ x ≈ ρ x
 
+  infix 5 _≈s_
+
   -- reflexivity of the equality of substitutions
   refl-subst : ∀ {Γ Δ : Context} {f : substitution Σ Γ Δ} → f ≈s f
   refl-subst = λ x → eq-refl
@@ -38,8 +40,8 @@ module SingleSorted.Substitution {ℓ} {Σ : Signature} (T : Theory ℓ Σ) wher
   tm-var-id {x = tm-oper f x} = eq-congr (λ i → tm-var-id)
 
   -- any two substitutions into the empty context are equal
-  empty-context-unique : ∀ {Γ : Context} {σ ρ : substitution Σ Γ empty-context} → σ ≈s ρ
-  empty-context-unique ()
+  empty-ctx-subst-unique : ∀ {Γ : Context} {σ ρ : substitution Σ Γ ctx-empty} → σ ≈s ρ
+  empty-ctx-subst-unique ()
 
   -- composition of substitutions is functorial
   subst-∘s : ∀ {Γ Δ Θ} {ρ : substitution Σ Δ Γ} {σ : substitution Σ Θ Δ} (t : Term Γ) → Θ ⊢ (t [ ρ ]s) [ σ ]s ≈ t [ ρ ∘s σ ]s
@@ -47,22 +49,32 @@ module SingleSorted.Substitution {ℓ} {Σ : Signature} (T : Theory ℓ Σ) wher
   subst-∘s (tm-oper f ts) = eq-congr (λ i → subst-∘s (ts i))
 
   -- substitution preserves equality
-  eq-subst : ∀ {Γ Δ : Context} (σ : substitution Σ Γ Δ) {u v : Term Δ} → Δ ⊢ u ≈ v → Γ ⊢ u [ σ ]s ≈ v [ σ ]s
-  eq-subst σ eq-refl = eq-refl
-  eq-subst σ (eq-symm ξ) = eq-symm (eq-subst σ ξ)
-  eq-subst σ (eq-tran ζ ξ) = eq-tran (eq-subst σ ζ) (eq-subst σ ξ)
-  eq-subst σ (eq-congr ξ) = eq-congr (λ i → eq-subst σ (ξ i))
-  eq-subst σ (eq-axiom ε ρ) = eq-tran (subst-∘s (eq-lhs ε)) (eq-tran (eq-axiom ε (ρ ∘s σ)) (eq-symm (subst-∘s (eq-rhs ε))))
+  eq-subst : ∀ {Γ Δ : Context} {σ : substitution Σ Γ Δ} {u v : Term Δ} → Δ ⊢ u ≈ v → Γ ⊢ u [ σ ]s ≈ v [ σ ]s
+  eq-subst eq-refl = eq-refl
+  eq-subst (eq-symm ξ) = eq-symm (eq-subst ξ)
+  eq-subst (eq-tran ζ ξ) = eq-tran (eq-subst ζ) (eq-subst ξ)
+  eq-subst (eq-congr ξ) = eq-congr (λ i → eq-subst (ξ i))
+  eq-subst {σ = σ} (eq-axiom ε ρ) = eq-tran (subst-∘s (eq-lhs ε)) (eq-tran (eq-axiom ε (ρ ∘s σ)) (eq-symm (subst-∘s (eq-rhs ε))))
 
  -- equivalent substitutions act the same on terms
-  equiv-subst : ∀ {Γ Δ : Context} (f g : substitution Σ Γ Δ)  → f ≈s g → ( ∀ x → Γ ⊢ x [ f ]s ≈ x [ g ]s)
-  equiv-subst f g p (tm-var x) = p x
-  equiv-subst f g p (tm-oper f₁ x) = eq-congr (λ i → equiv-subst f g p (x i))
+  equiv-subst : ∀ {Γ Δ : Context} {σ τ : substitution Σ Γ Δ} u → σ ≈s τ → Γ ⊢ u [ σ ]s ≈ u [ τ ]s
+  equiv-subst (tm-var x) ξ = ξ x
+  equiv-subst (tm-oper f ts) ξ = eq-congr (λ i → equiv-subst (ts i) ξ)
 
  -- equivalent substitution preserve equality
-  equiv-eq-subst : ∀ {Γ Δ : Context} (f g : substitution Σ Γ Δ) {u v : Term Δ} (p : f ≈s g) → Δ ⊢ u ≈ v → Γ ⊢ u [ f ]s ≈ v [ g ]s
-  equiv-eq-subst f g {u} {.u} p eq-refl = equiv-subst f g p u
-  equiv-eq-subst f g {u} {v} p (eq-symm q) = eq-symm  (equiv-eq-subst g f {v} {u} (symm-subst p) q)
-  equiv-eq-subst f g {u} {v} p (eq-tran {t = t} q q₁ ) =  eq-tran (eq-subst f q) (equiv-eq-subst f g {t} {v} (p) q₁)
-  equiv-eq-subst {Γ} {Δ} f g {.(tm-oper _ _)} {.(tm-oper  _ _)} p (eq-congr x) = eq-congr λ i → equiv-eq-subst f g p (x i)
-  equiv-eq-subst f g {.(eq-lhs ε [ σ ]s)} {.(eq-rhs ε [ σ ]s)} p (eq-axiom ε σ) = eq-tran (eq-subst f (eq-axiom ε σ)) (equiv-subst f g p (eq-rhs ε [ σ ]s))
+  equiv-eq-subst : ∀ {Γ Δ : Context} {σ τ : substitution Σ Γ Δ} {u v : Term Δ} → σ ≈s τ → Δ ⊢ u ≈ v → Γ ⊢ u [ σ ]s ≈ v [ τ ]s
+  equiv-eq-subst {u = u} p eq-refl = equiv-subst u p
+  equiv-eq-subst p (eq-symm q) = eq-symm  (equiv-eq-subst (symm-subst p) q)
+  equiv-eq-subst p (eq-tran q r) = eq-tran (eq-subst q) (equiv-eq-subst p r)
+  equiv-eq-subst p (eq-congr ξ) = eq-congr λ i → equiv-eq-subst p (ξ i)
+  equiv-eq-subst {σ = σ} {τ = τ} p (eq-axiom ε θ) = eq-tran (eq-subst (eq-axiom ε θ)) (equiv-subst (eq-rhs ε [ θ ]s) p)
+
+  -- the pairing of two substitutions
+  ⟨_,_⟩s : ∀ {Γ Δ Θ} (σ : substitution Σ Γ Δ) (ρ : substitution Σ Γ Θ) → substitution Σ Γ (ctx-concat Δ Θ)
+  ⟨ σ , ρ ⟩s (var-inl x) = σ x
+  ⟨ σ , ρ ⟩s (var-inr y) = ρ y
+
+  -- composition of substitutions preserves equality
+  ∘s-resp-≈s : ∀ {Γ Δ Θ} {σ₁ σ₂ : substitution Σ Γ Δ} {τ₁ τ₂ : substitution Σ Δ Θ} →
+               τ₁ ≈s τ₂ → σ₁ ≈s σ₂ → τ₁ ∘s σ₁ ≈s τ₂ ∘s σ₂
+  ∘s-resp-≈s ξ ζ z = equiv-eq-subst ζ (ξ z)

--- a/src/SingleSorted/UniversalInterpretation.agda
+++ b/src/SingleSorted/UniversalInterpretation.agda
@@ -15,7 +15,7 @@ module SingleSorted.UniversalInterpretation
   open SyntacticCategory T
 
   -- The universal interpretation in the syntactic category
-  ℐ : Interpretation.Interpretation Σ 𝒮
+  ℐ : Interpretation.Interpretation Σ cartesian-𝒮
   ℐ =
     record
      { interp-carrier = ctx-slot

--- a/src/SingleSorted/UniversalInterpretation.agda
+++ b/src/SingleSorted/UniversalInterpretation.agda
@@ -1,0 +1,31 @@
+open import SingleSorted.AlgebraicTheory
+
+import SingleSorted.Interpretation as Interpretation
+import SingleSorted.SyntacticCategory as SyntacticCategory
+import SingleSorted.Substitution as Substitution
+
+
+module SingleSorted.UniversalInterpretation
+  {ℓt}
+  {Σ : Signature}
+  (T : Theory ℓt Σ) where
+
+  open Theory T
+  open Substitution T
+  open SyntacticCategory T
+
+  -- The universal interpretation in the syntactic category
+  ℐ : Interpretation.Interpretation Σ 𝒮
+  ℐ =
+    record
+     { interp-carrier = ctx-slot
+     ; interp-power = power-𝒮
+     ; interp-oper = λ f var-var → tm-oper f (λ i → tm-var i)
+     }
+
+  open Interpretation.Interpretation ℐ
+
+  -- A term is essentially interpreted by itself
+  interp-term-self : ∀ {Γ} (t : Term Γ) y → Γ ⊢ interp-term t y ≈ t
+  interp-term-self (tm-var x) _ = eq-refl
+  interp-term-self (tm-oper f xs) y = eq-congr (λ i → interp-term-self (xs i) var-var)

--- a/src/SingleSorted/UniversalModel.agda
+++ b/src/SingleSorted/UniversalModel.agda
@@ -1,0 +1,31 @@
+import Relation.Binary.Reasoning.Setoid as SetoidR
+open import SingleSorted.AlgebraicTheory
+
+import SingleSorted.Interpretation as Interpretation
+import SingleSorted.Model as Model
+import SingleSorted.UniversalInterpretation as UniversalInterpretation
+import SingleSorted.Substitution as Substitution
+
+module SingleSorted.UniversalModel
+  {ℓt}
+  {Σ : Signature}
+  (T : Theory ℓt Σ) where
+
+  open Theory T
+  open Substitution T
+  open UniversalInterpretation T
+  open Interpretation.Interpretation ℐ
+
+  𝒰 : Model.Model T ℐ
+  𝒰 =
+     record
+        { model-eq =
+            λ ε var-var →
+              let open SetoidR (eq-setoid (eq-ctx ε)) in
+                begin
+                interp-term (eq-lhs ε) var-var   ≈⟨ interp-term-self (eq-lhs ε) var-var ⟩
+                eq-lhs ε                         ≈⟨ id-action ⟩
+                eq-lhs ε [ id-substitution ]s    ≈⟨ eq-axiom ε id-substitution ⟩
+                eq-rhs ε [ id-substitution ]s    ≈˘⟨  id-action ⟩
+                eq-rhs ε                         ≈˘⟨ interp-term-self (eq-rhs ε) var-var ⟩
+                interp-term (eq-rhs ε) var-var   ∎ }

--- a/src/SingleSorted/UniversalModel.agda
+++ b/src/SingleSorted/UniversalModel.agda
@@ -5,6 +5,7 @@ import SingleSorted.Interpretation as Interpretation
 import SingleSorted.Model as Model
 import SingleSorted.UniversalInterpretation as UniversalInterpretation
 import SingleSorted.Substitution as Substitution
+import SingleSorted.SyntacticCategory as SyntacticCategory
 
 module SingleSorted.UniversalModel
   {ℓt}
@@ -15,8 +16,9 @@ module SingleSorted.UniversalModel
   open Substitution T
   open UniversalInterpretation T
   open Interpretation.Interpretation ℐ
+  open SyntacticCategory T
 
-  𝒰 : Model.Model T ℐ
+  𝒰 : Model.Model T cartesian-𝒮 ℐ
   𝒰 =
      record
         { model-eq =


### PR DESCRIPTION
This pull request reorganizes how we work with powers and cartesian structure.

### Cartesian structure

Instead of having contexts generated by the empty context and context extension, we have

1. the empty context `ctx-empty`
2. the context with a single variable slot `ctx-slot`
3. context concatenation `ctx-concat Γ Δ`

Such contexts are isomorphic to the original ones, but they are structures as binary trees instead of lists. Accordingly de Bruijn indices are not natural numbers anymore, but locations in such trees (see the new definition of `var`).

The advantage of this approach is that we can very easily prove that the syntactic category has cartesian structure, because the product of `Γ` and `Δ` is simply `ctx-concat Γ Δ`. We avoid all complications about natural numbers (we do not even use natural numbers anymore!).

`FactsCartesian` is probably obsolete now.

### Powers

Given a cartesian structure on a category `C` we can define powers of objects (see `SingleSorted.Power.StandardPowered`) but we do *not* always have to use these precise powers. For example, in the syntactic category `Γ` is the power of `ctx-slot` by `Γ` but is only isomorphic `standard-pow ctx-slot Γ`. This is very painful because we keep translating between the two isomorphic copies.

The solutin is to define `Interpreation` in a different way. Namely, an interpretation should be allowed to choose how powers are computed (it should *not* prescribe that standard powers should always be used). So we define what it means to have a choice of powers on an object, and then an interpretation consists of:

* a carrier object `interp-carrier`
* a choice of powers of `interp-carrier`, called `interp-pow` (an instance of `Power.Powered interp-carrier`)
* an interpretation of function symbols which uses `interp-pow` to compute powers

Now the advantage is that the syntactic category can choose to compute the power `pow ctx-slot Γ` as `Γ` which eliminates all transfers between `Γ` and `pow ctx-slot Γ`. The definition of the universal interpretation and universal model becomes very easy.
