### PR TITLE
Redefine the relative monad on the J^M functor.

### DIFF
--- a/src/SecondOrder/Instantiation.agda
+++ b/src/SecondOrder/Instantiation.agda
@@ -98,7 +98,6 @@ module SecondOrder.Instantiation
       (≈ˢ-idˢ-[]ˢ (λ { (var-inl _) → ≈-refl ; (var-inr _) → ≈-refl}))
 
 
-
   -- Interactions involving instantiations
 
   -- the identity metavariable instantiation
@@ -183,7 +182,9 @@ module SecondOrder.Instantiation
                    ([]ᵛ-resp-≡ᵛ (λ { (var-inl x) → refl ; (var-inr x) → refl }))
                    [∘ᵛ])))
 
-  ⇑ˢ-resp-ⁱ∘ˢ : ∀ {Θ ψ Γ Δ Ξ} → {I : Θ ⇒ⁱ ψ ⊕ Δ} → {σ : Θ ⊕ Γ ⇒ˢ Δ} → ⇑ˢ {Ξ = Ξ} (I ⁱ∘ˢ σ) ≈ˢ ⇑ⁱ I ⁱ∘ˢ ⇑ˢ σ
+
+  ⇑ˢ-resp-ⁱ∘ˢ : ∀ {Θ ψ Γ Δ Ξ} → {I : Θ ⇒ⁱ ψ ⊕ Δ} → {σ : Θ ⊕ Γ ⇒ˢ Δ}
+    → ⇑ˢ {Ξ = Ξ} (I ⁱ∘ˢ σ) ≈ˢ ⇑ⁱ I ⁱ∘ˢ ⇑ˢ σ
   ⇑ˢ-resp-ⁱ∘ˢ {σ = σ} (var-inl x) = [ᵛ∘ⁱ] (σ x)
   ⇑ˢ-resp-ⁱ∘ˢ (var-inr x) = ≈-refl
 
@@ -213,7 +214,7 @@ module SecondOrder.Instantiation
           (≈ˢ-sym ⇑ˢ-resp-ⁱ∘ˢ)
           ([]ⁱ-resp-≈ⁱ (es i) (≈ⁱ-sym (⇑ⁱ-resp-ᵛ∘ⁱ {I = I}))))
 
-  -- the action of a composition
+  -- the action of a composition is functorial
 
   [∘ⁱ] : ∀ {Θ Ξ Ω Γ} → {I : Θ ⇒ⁱ Ξ ⊕ Γ} → {J : Ξ ⇒ⁱ Ω ⊕ Γ} →
            ∀ {A} → ∀ (t : Term Θ Γ A) → [ J ∘ⁱ I ]ⁱ t ≈ [ J ]ⁱ [ I ]ⁱ t

--- a/src/SecondOrder/Mslot.agda
+++ b/src/SecondOrder/Mslot.agda
@@ -4,8 +4,8 @@ open import Agda.Primitive using (lzero; lsuc; _⊔_)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; sym; trans; cong; subst; setoid)
 open import Data.Product using (_×_; Σ; _,_; proj₁; proj₂; zip; map; <_,_>; swap)
 import Function.Equality
-open import Relation.Binary using (Setoid)
-import Relation.Binary.Reasoning.Setoid as SetoidR
+-- open import Relation.Binary using (Setoid)
+-- import Relation.Binary.Reasoning.Setoid as SetoidR
 
 import Categories.Category
 import Categories.Functor
@@ -70,64 +70,20 @@ module SecondOrder.Mslot
     open NaturalTransformation
     open Function.Equality renaming (_∘_ to _∙_)
 
-    ∘ᵥ-resp-≈ : ∀ {o l e o' l' e'} {𝒞 : Category o l e} {𝒟 : Category o' l' e'}
-                {F G H : Functor 𝒞 𝒟} {α β : NaturalTransformation F G} {γ δ : NaturalTransformation G H}
-              → (∀ {X : Obj 𝒞} → (𝒟 Category.≈ (η α X)) (η β X))
-              → (∀ {X : Obj 𝒞} → (𝒟 Category.≈ (η γ X)) (η δ X))
-              -------------------------------------------------------------------
-              → (∀ {X : Obj 𝒞} → (𝒟 Category.≈ (η (γ ∘ᵥ α) X)) (η (δ ∘ᵥ β) X))
-    ∘ᵥ-resp-≈ {𝒟 = 𝒟} α≈β γ≈δ {X = X} = ∘-resp-≈ 𝒟 γ≈δ α≈β
-
-
-  MCodom : Category (lsuc ℓ) ℓ ℓ
-  MCodom =
-    let open Category in
-    let open Functor in
-    let open NaturalTransformation in
-    let open Function.Equality using (_⟨$⟩_) renaming (cong to func-cong) in
-    let open Category.HomReasoning in
-    record
-    { Obj = Functor MTele (Functors VTele (Setoids ℓ ℓ))
-    ; _⇒_ = NaturalTransformation
-    ; _≈_ = λ {F} {G} α β → ∀ (ψ : Obj MTele) (Γ : Obj VTele)
-          → (Setoids ℓ ℓ Category.≈ (η ((η α) ψ) Γ)) (η ((η β) ψ) Γ)
-    ; id = idNt
-    ; _∘_ = _∘ᵥ_
-    ; assoc = λ ψ Γ x≈y → Setoid.refl {!setoid ([ !}
-    ; sym-assoc = λ ψ Γ x≈y → Setoid.refl {!!}
-    ; identityˡ = λ {F} {G} {α} ψ Γ x≈y → Setoid.refl {!!}
-    ; identityʳ = λ ψ Γ x → Setoid.refl {!!}
-    ; identity² = Setoid.refl {!!}
-    ; equiv = record
-              { refl = Setoid.refl {!!}
-              ; sym = Setoid.sym {!!}
-              ; trans = Setoid.trans {!!}
-              }
-    ; ∘-resp-≈ = λ {F} {G} {H} {α} {β} {γ} {δ} α≈β γ≈δ ψ Γ
-      → ∘ᵥ-resp-≈ {α = γ} {δ} {γ = α} {β} (γ≈δ _ _) (α≈β _ _)
-    }
-
-  Mslots : Functor MContexts (IndexedCategory sort (MCodom))
-  Mslots =
+  Mslots : Functor MContexts (IndexedCategory VContext (IndexedCategory sort (Setoids ℓ ℓ)))
+  Mslots =  
     let open Categories.NaturalTransformation in
     let open NaturalTransformation in
-          record
-            { F₀ = λ Θ A →
-                 record
-                 { F₀ = λ Ψ → record
-                                { F₀ = λ Γ → setoid ([ Γ , A ]∈ (Θ ,, Ψ))
-                                ; F₁ = λ {Γ} {Γ'} ρ → record { _⟨$⟩_ = λ M → {!!} ; cong = {!!} }
-                                ; identity = λ M≡N → {!!}
-                                ; homomorphism = {!!}
-                                ; F-resp-≈ = {!!}
-                                }
-                 ; F₁ = λ ι → {!!}
-                 ; identity = λ t≈s → {!!}
-                 ; homomorphism = λ t≈s → {!!}
-                 ; F-resp-≈ = λ ι≡μ t≈s → {!!}
-                 }
-            ; F₁ = {!!}
-            ; identity = {!!}
-            ; homomorphism = {!!}
-            ; F-resp-≈ = {!!}
-            }
+    let open Relation.Binary.PropositionalEquality.≡-Reasoning in
+      record
+        { F₀ = λ Θ Γ A → setoid ([ Γ , A ]∈ Θ)
+        ; F₁ = λ ι Γ A → record { _⟨$⟩_ = λ M → ι M ; cong = λ M≡N → cong ι M≡N }
+        ; identity = λ {Θ} Γ A {M} {N} M≡N → cong idᵐ M≡N
+        ; homomorphism = λ {Θ} {Ψ} {Ξ} {ι} {μ} Γ A M≡N → cong (μ ∘ᵐ ι) M≡N
+        ; F-resp-≈ = λ {Θ} {Ψ} {ι} {μ} ι≡ᵐμ Γ A {M} {N} M≡N →
+                   begin
+                   ι M ≡⟨ cong ι M≡N ⟩
+                   ι N ≡⟨ ι≡ᵐμ N ⟩
+                   μ N
+                   ∎
+        }


### PR DESCRIPTION
Also redefine the J^M functor in line with the rework of the general
theory.
Compared to the previous definition this one doesn't bake in the
notion of extension of contexts and doesn't have extensions of
metacontexts at all. The definiion is now much simpler and should
allow us to express the relaton between the two relative monads (the
context and metacontext ones).